### PR TITLE
Demonstrate setting up clean up after Pipeline is done executing

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,14 +1,28 @@
 pipeline {
     agent any
     stages {
-        stage('Deploy') {
-           steps {
-               timeout(time: 3, unit: 'MINUTES') {
-                   retry(5) {
-                       sh './flakey-deploy.sh'
-                   }
-               }
-           }
+        stage('Test') {
+            steps {
+                sh 'echo "Fail!"; exit 1'
+            }
+        }
+    }
+    post {
+        always {
+            echo 'This will always run'
+        }
+        success {
+            echo 'This will run only if successful'
+        }
+        failure {
+            echo 'This will run only if failed'
+        }
+        unstable {
+            echo 'This will run only if the run was marked as unstable'
+        }
+        changed {
+            echo 'This will run only if the state of the Pipeline has changed'
+            echo 'For example, if the Pipeline was previously failing but it now successful'
         }
     }
 }


### PR DESCRIPTION
Demonstrates cleaning after Pipeline execution is complete. Caters for when you may need to run clean-up steps or perform some actions based on the outcome of the Pipeline.

These actions are performed in the `post` section.