### PR TITLE
Demonstrate defining variables inside Jenkinsfile

### DIFF
--- a/env-var-Jenkinsfile
+++ b/env-var-Jenkinsfile
@@ -1,0 +1,16 @@
+pipeline {
+    agent any
+
+    environment {
+        DISABLE_AUTH = 'true'
+        DB_ENGINE = 'sqlite'
+    }
+
+    stages {
+        stage('Build') {
+            steps {
+                sh 'printenv'
+            }
+        }
+    }
+}


### PR DESCRIPTION
Added a `Jenkinsfile` that demonstrates how environment variables can be defined inside the `Jenkinsfile`.

Useful for instructing scripts to configure the build or tests differently to run them inside Jenkins