### PR TITLE
Recording tests artifacts

### DIFF
--- a/collect-test-results-artifacts-Jenkinsfile
+++ b/collect-test-results-artifacts-Jenkinsfile
@@ -1,0 +1,22 @@
+pipeline {
+    agent any {
+        stages {
+            stage('Build') {
+                steps {
+                    sh './gradlew build'
+                }
+            }
+            stage('Test') {
+                steps {
+                    sh './gradlew check'
+                }
+            }
+        }
+
+        post {
+            always {
+                junit 'build/reports/**/*.xml'
+            }
+        }
+    }
+}

--- a/grab-build-artifacts-Jenkinsfile
+++ b/grab-build-artifacts-Jenkinsfile
@@ -1,0 +1,23 @@
+pipeline {
+    agent any {
+        stages {
+            stage('Build') {
+                steps {
+                    sh './gradlew build'
+                }
+            }
+            stage('Test') {
+                steps {
+                    sh './gradlew check'
+                }
+            }
+        }
+
+        post {
+            always {
+                archiveArtifacts artifacts: 'build/libs/**/*.jar', fingerprint: true
+                junit 'build/reports/**/*.xml'
+            }
+        }
+    }
+}


### PR DESCRIPTION
Added `Jenkinsfile`s that show how test results can be collected and built artifacts grabbed from Jenkins for local analysis and investigation.

NB: **artifacts** are files generated during the execution of the Jenkins Pipeline.